### PR TITLE
fix: bastionサーバー修正。CVE-2025-55182 / 66478の脆弱性対策のためdockerバージョンの修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,25 @@
 #### langfuse確認URL
 以下はAWS管理画面コンソールのALBのAレコードの例
 - http://sst-test-langfuse-alb-production-150477180.ap-northeast-1.elb.amazonaws.com
+
+### langfuse用のスクリプトを実行する方法
+- langfuseの管理画面UIで以下を実行する
+```
+Organization作成->project名作成->最後に API Keys を選択の上、Create new API Keysを押下します
+```
+
+- 上記を行うとSecretキーとPublicキー、Host名の払い出しがされるのでローカル環境で以下を実行し環境変数の設定を行う
+```
+export LANGFUSE_SECRET_KEY="YOUR_SECRET_KEY"
+export LANGFUSE_PUBLIC_KEY="YOUR_PUBLIC_KEY"
+export LANGFUSE_HOST="YOUR_LANGFUSE_URL"
+export OPENAI_API_KEY="OPENAI_API_KEY"
+```
+
+- 以下コマンドでスクリプトを実行
+```
+uv run hello.py
+```
+
+- 参考資料
+https://kiririmode.hatenablog.jp/entry/20250106/1736142208

--- a/app/async-worker/Dockerfile
+++ b/app/async-worker/Dockerfile
@@ -1,3 +1,1 @@
-# FROM langfuse/langfuse-worker:3.73.0
-# FROM langfuse/langfuse-worker:latest
-FROM langfuse/langfuse-worker:3.76.0
+FROM langfuse/langfuse-worker:3.139.0

--- a/app/async-worker/Dockerfile
+++ b/app/async-worker/Dockerfile
@@ -1,1 +1,1 @@
-FROM langfuse/langfuse-worker:3.139.0
+FROM langfuse/langfuse-worker:3.155.1

--- a/app/clickhouse/Dockerfile
+++ b/app/clickhouse/Dockerfile
@@ -1,3 +1,1 @@
-# FROM clickhouse/clickhouse-server:25.3.3-alpine
-# FROM clickhouse/clickhouse-server:head-alpine
-FROM clickhouse/clickhouse-server:25.6.2.5-alpine
+FROM clickhouse/clickhouse-server:25.6.2-alpine

--- a/app/clickhouse/Dockerfile
+++ b/app/clickhouse/Dockerfile
@@ -1,1 +1,1 @@
-FROM clickhouse/clickhouse-server:25.6.2-alpine
+FROM clickhouse/clickhouse-server:25.8.1-alpine

--- a/app/web-server/Dockerfile
+++ b/app/web-server/Dockerfile
@@ -1,3 +1,1 @@
-# FROM langfuse/langfuse:3.73.0
-# FROM langfuse/langfuse:latest
-FROM langfuse/langfuse:3.76.0
+FROM langfuse/langfuse:3.139.0

--- a/app/web-server/Dockerfile
+++ b/app/web-server/Dockerfile
@@ -1,1 +1,1 @@
-FROM langfuse/langfuse:3.139.0
+FROM langfuse/langfuse:3.155.1

--- a/infra/alb.ts
+++ b/infra/alb.ts
@@ -105,7 +105,7 @@ new aws.route53.Record(
   {
     zoneId: infraConfigResources.hostedZone.zoneId,
     name: `alb.langfuse.${infraConfigResources.domainName}`,
-    type: aws.route53.RecordType.A,
+    type: "A",
     aliases: [
       {
         name: alb.dnsName,

--- a/infra/bastion.ts
+++ b/infra/bastion.ts
@@ -35,6 +35,9 @@ const ecsExecPolicy = new aws.iam.Policy(
             "ssm:TerminateSession",
             "ssm:GetConnectionStatus",
             "logs:*",
+            "ecs:DescribeTasks",
+            "s3:GetObject",
+            "s3:PutObject"
           ],
           Resource: "*"
         }
@@ -85,92 +88,51 @@ const ami = aws.ec2.getAmi({
   ],
 });
 
-// 共通 UserData（Spot 中断で再作成されても自動実行）
-const rawUserData = `#!/bin/bash
-cd /home/ssm-user
-sudo yum update -y
-sudo dnf install -y postgresql15 nodejs
-psql --version
-# --- SSM Agent 再インストール（念のため） ---
-sudo dnf remove -y amazon-ssm-agent || true
-sudo dnf install -y https://s3.ap-northeast-1.amazonaws.com/amazon-ssm-ap-northeast-1/latest/linux_amd64/amazon-ssm-agent.rpm
-sudo systemctl enable --now amazon-ssm-agent
-# --- pnpm ---
-export PNPM_VERSION=9.10.0
-curl -fsSL https://get.pnpm.io/install.sh | bash -
-export PNPM_HOME="$HOME/.local/share/pnpm"
-export PATH="$PNPM_HOME:$PATH"
-# --- redis-cli (TLS) ---
-sudo dnf install -y gcc gcc-c++ openssl-devel
-curl -s http://download.redis.io/redis-stable.tar.gz -o redis-stable.tar.gz
-tar zxf redis-stable.tar.gz
-cd redis-stable/
-make distclean && make redis-cli BUILD_TLS=yes
-sudo install -m 0755 src/redis-cli /usr/local/bin/
-redis-cli -v
-# --- ClickHouse Client ---
-cd /home/ssm-user
-sudo curl -o /etc/yum.repos.d/altinity.repo https://builds.altinity.cloud/yum-repo/altinity.repo
-sudo curl -o /etc/pki/rpm-gpg/RPM-GPG-KEY-altinity https://builds.altinity.cloud/yum-repo/RPM-GPG-KEY-altinity
-sudo rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-altinity
-sudo dnf clean all
-sudo dnf install -y clickhouse-client
-clickhouse-client --version
-`;
-
-// ------------------------------------------------------------
-// 4. Launch Template（Spot）
-// ------------------------------------------------------------
-const bastionLaunchTemplate = new aws.ec2.LaunchTemplate(
-  `${infraConfigResources.idPrefix}-bastion-lt-${$app.stage}`,
+// 5. EC2 Instance
+const bastionInstance = new aws.ec2.Instance(
+  `${infraConfigResources.idPrefix}-bastion-${$app.stage}`,
   {
-    namePrefix: `${infraConfigResources.idPrefix}-bastion-`,
-    imageId: ami.then((a) => a.id),
+    ami: ami.then(a => a.id),
     instanceType: "t3.large",
-    iamInstanceProfile: { name: bastionInstanceProfile.name },
+    subnetId: vpcResources.bastionProtectedSubnet1a.id, // 🔁 Private/Public どちらでもOK（SSM用ならPrivateでも可）
     vpcSecurityGroupIds: [bastionSecurityGroup.id],
-    userData: Buffer.from(rawUserData).toString("base64"),
-    tagSpecifications: [
-      {
-        resourceType: "instance",
-        tags: {
-          Name: `${infraConfigResources.idPrefix}-bastion-${$app.stage}`,
-        },
-      },
-    ],
-    instanceMarketOptions: {
-      marketType: "spot",
-      spotOptions: {
-        spotInstanceType: "one-time", // ASG が維持するので one-time で十分
-        instanceInterruptionBehavior: "terminate",
-      },
+    iamInstanceProfile: bastionInstanceProfile.name,
+    userData: `#!/bin/bash
+    cd /home/ssm-user
+    sudo yum update -y
+    sudo dnf install -y postgresql16 nodejs
+    psql --version
+    sudo yum install -y https://s3.ap-northeast-1.amazonaws.com/amazon-ssm-ap-northeast-1/latest/linux_amd64/amazon-ssm-agent.rpm
+    sudo dnf remove -y amazon-ssm-agent || true
+    sudo dnf install -y amazon-ssm-agent
+    sudo dnf install -y https://s3.amazonaws.com/session-manager-downloads/plugin/latest/linux_64bit/session-manager-plugin.rpm
+    sudo systemctl enable --now amazon-ssm-agent
+    session-manager-plugin --version
+    export PNPM_VERSION=9.10.0
+    curl -fsSL https://get.pnpm.io/install.sh | bash -
+    export PNPM_HOME="$HOME/.local/share/pnpm"
+    export PATH="$PNPM_HOME:$PATH"
+    sudo dnf install -y gcc gcc-c++ openssl-devel
+    curl -s http://download.redis.io/redis-stable.tar.gz -o redis-stable.tar.gz
+    tar zxf redis-stable.tar.gz
+    cd redis-stable/
+    make distclean
+    make redis-cli BUILD_TLS=yes
+    sudo install -m 0755 src/redis-cli /usr/local/bin/
+    which redis-cli
+    redis-cli -v
+    set +H
+    cd /home/ssm-user
+    sudo curl -o /etc/yum.repos.d/altinity.repo https://builds.altinity.cloud/yum-repo/altinity.repo
+    sudo curl -o /etc/pki/rpm-gpg/RPM-GPG-KEY-altinity https://builds.altinity.cloud/yum-repo/RPM-GPG-KEY-altinity
+    sudo rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-altinity
+    sudo dnf clean all
+    sudo dnf install -y clickhouse-client
+    clickhouse-client --version
+    `,
+    tags: {
+      Name: `${infraConfigResources.idPrefix}-bastion-${$app.stage}`,
     },
-  }
-);
-
-const bastionAsg = new aws.autoscaling.Group(
-  `${infraConfigResources.idPrefix}-bastion-asg-${$app.stage}`,
-  {
-    desiredCapacity: 1,
-    maxSize: 1,
-    minSize: 1,
-    vpcZoneIdentifiers: [vpcResources.bastionProtectedSubnet1a.id], // 必要なら複数サブネットを並べて AZ 冗長
-    launchTemplate: {
-      id: bastionLaunchTemplate.id,
-      version: "$Latest",
-    },
-    capacityRebalance: true, // Spot 中断警告時に先行して補充
-    tags: [
-      {
-        key: "Name",
-        value: `${infraConfigResources.idPrefix}-bastion-${$app.stage}`,
-        propagateAtLaunch: true,
-      },
-    ],
-    /*
-    healthCheckType: "EC2",            // SSM だけなら EC2 ヘルスでも十分
-    healthCheckGracePeriod: 180,
-    */
   }
 );
 

--- a/infra/rds.ts
+++ b/infra/rds.ts
@@ -59,8 +59,8 @@ const cluster = new aws.rds.Cluster(
   `${infraConfigResources.idPrefix}-aurora-serverless-cluster-${$app.stage}`,
   {
     clusterIdentifier: `${infraConfigResources.idPrefix}-aurora-serverless-cluster-${$app.stage}`,
-    engine: aws.rds.EngineType.AuroraPostgresql,
-    engineMode: aws.rds.EngineMode.Provisioned,
+    engine: "aurora-postgresql",
+    engineMode: "provisioned",
     engineVersion: "16.6",
     databaseName: "langfuse",
     masterUsername: masterUsername,
@@ -152,7 +152,7 @@ new aws.ssm.Parameter(
   `${infraConfigResources.idPrefix}-database-name-${$app.stage}`,
   {
     name: `/${infraConfigResources.idPrefix}/langfuse/${$app.stage}/rds/database/name`,
-    type: aws.ssm.ParameterType.String,
+    type: "String",
     value: cluster.databaseName,
   }
 );
@@ -162,7 +162,7 @@ new aws.ssm.Parameter(
   `${infraConfigResources.idPrefix}-host-name-${$app.stage}`,
   {
     name: `/${infraConfigResources.idPrefix}/langfuse/${$app.stage}/rds/host/name`,
-    type: aws.ssm.ParameterType.String,
+    type: "String",
     value: cluster.endpoint.apply(ep => ep.split(":"))[0],
   }
 );

--- a/infra/s3.ts
+++ b/infra/s3.ts
@@ -1,6 +1,6 @@
 import { infraConfigResources } from "./infra-config";
 
-const albAccessLogBucket = new aws.s3.BucketV2(
+const albAccessLogBucket = new aws.s3.Bucket(
   `${infraConfigResources.idPrefix}-alb-access-log-bucket-${$app.stage}`,
   {
     bucket: `${infraConfigResources.idPrefix}-alb-access-log-bucket-${$app.stage}`,
@@ -23,7 +23,7 @@ const albAccessLogBucket = new aws.s3.BucketV2(
   },
 );
 
-const albConnectionLogBucket = new aws.s3.BucketV2(
+const albConnectionLogBucket = new aws.s3.Bucket(
   `${infraConfigResources.idPrefix}-alb-connection-log-bucket-${$app.stage}`,
   {
     bucket: `${infraConfigResources.idPrefix}-alb-connection-log-bucket-${$app.stage}`,
@@ -47,7 +47,7 @@ const albConnectionLogBucket = new aws.s3.BucketV2(
 );
 
 // ログバケット
-const cloudFrontLogBucket = new aws.s3.BucketV2(
+const cloudFrontLogBucket = new aws.s3.Bucket(
   `${infraConfigResources.idPrefix}-cloudfront-log-bucket-${$app.stage}`,
   {
     bucket: `${infraConfigResources.idPrefix}-cloudfront-log-bucket-${$app.stage}`,
@@ -81,11 +81,11 @@ new aws.s3.BucketOwnershipControls(
   },
 );
 
-const langfuseBlobBucket = new aws.s3.BucketV2(
+const langfuseBlobBucket = new aws.s3.Bucket(
   `${infraConfigResources.idPrefix}-blob-bucket-${$app.stage}`,
   {
     bucket: `${infraConfigResources.idPrefix}-blob-bucket-${$app.stage}`,
-    forceDestroy: true,
+    forceDestroy: false,
   },
 );
 
@@ -100,11 +100,11 @@ new aws.s3.BucketOwnershipControls(
   },
 );
 
-const langfuseEventBucket = new aws.s3.BucketV2(
+const langfuseEventBucket = new aws.s3.Bucket(
   `${infraConfigResources.idPrefix}-event-bucket-${$app.stage}`,
   {
     bucket: `${infraConfigResources.idPrefix}-event-bucket-${$app.stage}`,
-    forceDestroy: true,
+    forceDestroy: false,
   },
 );
 
@@ -119,11 +119,11 @@ new aws.s3.BucketOwnershipControls(
   },
 );
 
-const langfuseClickhouseBucket = new aws.s3.BucketV2(
+const langfuseClickhouseBucket = new aws.s3.Bucket(
   `${infraConfigResources.idPrefix}-clickhouse-bucket-${$app.stage}`,
   {
     bucket: `${infraConfigResources.idPrefix}-clickhouse-bucket-${$app.stage}`,
-    forceDestroy: true,
+    forceDestroy: false,
   },
 );
 

--- a/infra/vpc.ts
+++ b/infra/vpc.ts
@@ -65,7 +65,6 @@ new aws.ec2.Route(
   }
 )
 
-// bastion用
 const publicSubnet1a = new aws.ec2.Subnet(
   `${infraConfigResources.idPrefix}-public-subnet-1a-${$app.stage}`,
   {
@@ -161,7 +160,7 @@ const protectedRouteTable1c = new aws.ec2.RouteTable(
 );
 protectedRouteTables.push(protectedRouteTable1c);
 
-if ($app.stage === "production" || $app.stage === "stg") {
+if ($app.stage === "dev") {
   const eip1c = new aws.ec2.Eip(
     `${infraConfigResources.idPrefix}-eip-1c-${$app.stage}`,
     {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "unlock": "sst unlock"
   },
   "dependencies": {
-    "@pulumi/aws": "^6.67.0",
+    "@pulumi/aws": "^7.0.0",
     "@pulumi/pulumi": "^3.167.0",
     "@pulumi/random": "^4.18.2",
     "@remix-run/node": "^2.15.2",
@@ -27,7 +27,7 @@
     "pulumi": "^0.0.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "sst": "3.14.24"
+    "sst": "4.1.3"
   },
   "devDependencies": {
     "@remix-run/dev": "^2.15.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@pulumi/aws':
-        specifier: ^6.67.0
-        version: 6.68.0(typescript@5.7.3)
+        specifier: ^7.0.0
+        version: 7.20.0(typescript@5.7.3)
       '@pulumi/pulumi':
         specifier: ^3.167.0
         version: 3.169.0(typescript@5.7.3)
@@ -39,8 +39,8 @@ importers:
         specifier: ^18.2.0
         version: 18.3.1(react@18.3.1)
       sst:
-        specifier: 3.14.24
-        version: 3.14.24
+        specifier: 4.1.3
+        version: 4.1.3
     devDependencies:
       '@remix-run/dev':
         specifier: ^2.15.2
@@ -593,10 +593,6 @@ packages:
   '@mdx-js/mdx@2.3.0':
     resolution: {integrity: sha512-jLuwRlz8DQfQNiUCJR50Y09CGPq3fLtmtUQfVrj79E0JWu3dvsVcxVIcfhR5h0iXu+/z++zDrYeiJqifRynJkA==}
 
-  '@modelcontextprotocol/sdk@1.6.1':
-    resolution: {integrity: sha512-oxzMzYCkZHMntzuyerehK3fV6A2Kwh5BD6CGEJSVDU2QNEhfLOptf2X7esQgaHZXHZY0oHmMsOtIDLP71UJXgA==}
-    engines: {node: '>=18'}
-
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -793,8 +789,8 @@ packages:
   '@protobufjs/utf8@1.1.0':
     resolution: {integrity: sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==}
 
-  '@pulumi/aws@6.68.0':
-    resolution: {integrity: sha512-uehJNSviSq3garkLXsy1zZzI7V6clBDQq8G83PSpNfdePdGeKtuRoxMSsuqkgpGkue+cGjoxJtC6QwdtzgaKBQ==}
+  '@pulumi/aws@7.20.0':
+    resolution: {integrity: sha512-f8efmjHXKRUQY4fojfw7vuWN7Q07Cz0bjqbIwD/qtOuz+qs+zrKWU50uAB0HcWXAxjI0ll4KslGu2oLRiMTxng==}
 
   '@pulumi/pulumi@3.169.0':
     resolution: {integrity: sha512-l8x+gTySKWG2dRGvlScfl9EJaYgymkcUFaNAaz7lONYcvqllXXVw/mhbnsleNhC02gDiuP0p/9CfctHLqf75+Q==}
@@ -1025,9 +1021,6 @@ packages:
     resolution: {integrity: sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==}
     engines: {node: '>=10'}
 
-  '@tsconfig/bun@1.0.7':
-    resolution: {integrity: sha512-udGrGJBNQdXGVulehc1aWT73wkR9wdaGBtB6yL70RJsqwW/yJhIg6ZbRlPOfIUiFNrnBuYLBi9CSmMKfDC7dvA==}
-
   '@tufjs/canonical-json@2.0.0':
     resolution: {integrity: sha512-yVtV8zsdo8qFHe+/3kw81dSLyF7D576A5cCFCi4X7B39tWT7SekaEFUnvnWJHz+9qO7qJTah1JbrDjWKqFtdWA==}
     engines: {node: ^16.14.0 || >=18.0.0}
@@ -1204,10 +1197,6 @@ packages:
     resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
     engines: {node: '>= 0.6'}
 
-  accepts@2.0.0:
-    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
-    engines: {node: '>= 0.6'}
-
   acorn-import-attributes@1.9.5:
     resolution: {integrity: sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==}
     peerDependencies:
@@ -1331,10 +1320,6 @@ packages:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
 
-  aws-sdk@2.1692.0:
-    resolution: {integrity: sha512-x511uiJ/57FIsbgUe5csJ13k3uzu25uWQE+XqfBis/sB0SFoiElJWXRkgEAUh0U6n40eT3ay5Ue4oPkRMu1LYw==}
-    engines: {node: '>= 10.0.0'}
-
   aws4fetch@1.0.18:
     resolution: {integrity: sha512-3Cf+YaUl07p24MoQ46rFwulAmiyCwH2+1zw1ZyPAX5OtJ34Hh185DwB8y/qRLb6cYYYtSFJ9pthyLc0MD4e8sQ==}
 
@@ -1374,10 +1359,6 @@ packages:
     resolution: {integrity: sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
 
-  body-parser@2.2.0:
-    resolution: {integrity: sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==}
-    engines: {node: '>=18'}
-
   brace-expansion@1.1.11:
     resolution: {integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==}
 
@@ -1398,9 +1379,6 @@ packages:
 
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
-
-  buffer@4.9.2:
-    resolution: {integrity: sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==}
 
   buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
@@ -1547,10 +1525,6 @@ packages:
     resolution: {integrity: sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==}
     engines: {node: '>= 0.6'}
 
-  content-disposition@1.0.0:
-    resolution: {integrity: sha512-Au9nRL8VNUut/XSzbQA38+M78dzP4D+eqg3gfJHMIHHYa3bg067xj1KxMUWj+VULbiZMowKngFFbKczUrNJ1mg==}
-    engines: {node: '>= 0.6'}
-
   content-type@1.0.5:
     resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
     engines: {node: '>= 0.6'}
@@ -1575,10 +1549,6 @@ packages:
 
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
-
-  cors@2.8.5:
-    resolution: {integrity: sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==}
-    engines: {node: '>= 0.10'}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -1967,18 +1937,6 @@ packages:
     resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
     engines: {node: '>=6'}
 
-  events@1.1.1:
-    resolution: {integrity: sha512-kEcvvCBByWXGnZy6JUlgAp2gBIUjfCAV6P6TgT1/aaQKcmuAEC4OZTV1I4EWQLz2gxZw76atuVyvHhTxvi0Flw==}
-    engines: {node: '>=0.4.x'}
-
-  eventsource-parser@3.0.2:
-    resolution: {integrity: sha512-6RxOBZ/cYgd8usLwsEl+EC09Au/9BcmCKYF2/xbml6DNczf7nv0MQb+7BA2F+li6//I+28VNlQR37XfQtcAJuA==}
-    engines: {node: '>=18.0.0'}
-
-  eventsource@3.0.7:
-    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
-    engines: {node: '>=18.0.0'}
-
   execa@5.1.1:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
     engines: {node: '>=10'}
@@ -1990,19 +1948,9 @@ packages:
   exponential-backoff@3.1.2:
     resolution: {integrity: sha512-8QxYTVXUkuy7fIIoitQkPwGonB8F3Zj8eEO8Sqg9Zv/bkI7RJAzowee4gr81Hak/dUTpA2Z7VfQgoijjPNlUZA==}
 
-  express-rate-limit@7.5.0:
-    resolution: {integrity: sha512-eB5zbQh5h+VenMPM3fh+nw1YExi5nMr6HUCR62ELSP11huvxm/Uir1H1QEyTkk5QX6A58pX6NmaTMceKZ0Eodg==}
-    engines: {node: '>= 16'}
-    peerDependencies:
-      express: ^4.11 || 5 || ^5.0.0-beta.1
-
   express@4.21.2:
     resolution: {integrity: sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==}
     engines: {node: '>= 0.10.0'}
-
-  express@5.1.0:
-    resolution: {integrity: sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==}
-    engines: {node: '>= 18'}
 
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
@@ -2046,10 +1994,6 @@ packages:
     resolution: {integrity: sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==}
     engines: {node: '>= 0.8'}
 
-  finalhandler@2.1.0:
-    resolution: {integrity: sha512-/t88Ty3d5JWQbWYgaOGCCYfXRwV1+be02WqYYlL6h0lEiUAMPM8o8qKGO01YIkOHzka2up08wvgYD0mDiI+q3Q==}
-    engines: {node: '>= 0.8'}
-
   find-up@5.0.0:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
     engines: {node: '>=10'}
@@ -2087,10 +2031,6 @@ packages:
   fresh@0.5.2:
     resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
     engines: {node: '>= 0.6'}
-
-  fresh@2.0.0:
-    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
-    engines: {node: '>= 0.8'}
 
   fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
@@ -2252,10 +2192,6 @@ packages:
   hast-util-whitespace@2.0.1:
     resolution: {integrity: sha512-nAxA0v8+vXSBDt3AnRUNjyRIQ0rD+ntpbAp4LnPkumc5M9yUbSMa4XDU9Q6etY4f1Wp4bNgvc1yjiZtsTTrSng==}
 
-  hono@4.7.4:
-    resolution: {integrity: sha512-Pst8FuGqz3L7tFF+u9Pu70eI0xa5S3LPUmrNd5Jm8nTHze9FxLTK9Kaj5g/k4UcwuJSXTP65SyHOPLrffpcAJg==}
-    engines: {node: '>=16.9.0'}
-
   hosted-git-info@6.1.3:
     resolution: {integrity: sha512-HVJyzUrLIL1c0QmviVh5E8VGyUS7xCFPS6yydaVd1UegW+ibV/CohqTH9MkOLDp5o+rb82DMo77PTuc9F/8GKw==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
@@ -2300,9 +2236,6 @@ packages:
     engines: {node: ^10 || ^12 || >= 14}
     peerDependencies:
       postcss: ^8.1.0
-
-  ieee754@1.1.13:
-    resolution: {integrity: sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==}
 
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
@@ -2477,9 +2410,6 @@ packages:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
 
-  is-promise@4.0.0:
-    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
-
   is-reference@3.0.3:
     resolution: {integrity: sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==}
 
@@ -2557,10 +2487,6 @@ packages:
   jiti@1.21.7:
     resolution: {integrity: sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==}
     hasBin: true
-
-  jmespath@0.16.0:
-    resolution: {integrity: sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw==}
-    engines: {node: '>= 0.6.0'}
 
   jose@4.15.9:
     resolution: {integrity: sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==}
@@ -2766,16 +2692,8 @@ packages:
     resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
     engines: {node: '>= 0.6'}
 
-  media-typer@1.1.0:
-    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
-    engines: {node: '>= 0.8'}
-
   merge-descriptors@1.0.3:
     resolution: {integrity: sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==}
-
-  merge-descriptors@2.0.0:
-    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
-    engines: {node: '>=18'}
 
   merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
@@ -2887,16 +2805,8 @@ packages:
     resolution: {integrity: sha512-oHlN/w+3MQ3rba9rqFr6V/ypF10LSkdwUysQL7GkXoTgIWeV+tcXGA852TBxH+gsh8UWoyhR1hKcoMJTuWflpg==}
     engines: {node: '>= 0.6'}
 
-  mime-db@1.54.0:
-    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
-    engines: {node: '>= 0.6'}
-
   mime-types@2.1.35:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
-    engines: {node: '>= 0.6'}
-
-  mime-types@3.0.1:
-    resolution: {integrity: sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==}
     engines: {node: '>= 0.6'}
 
   mime@1.6.0:
@@ -3027,10 +2937,6 @@ packages:
 
   negotiator@0.6.4:
     resolution: {integrity: sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==}
-    engines: {node: '>= 0.6'}
-
-  negotiator@1.0.0:
-    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
 
   node-gyp@10.3.1:
@@ -3169,10 +3075,6 @@ packages:
     resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
     engines: {node: '>=6'}
 
-  opencontrol@0.0.6:
-    resolution: {integrity: sha512-QeCrpOK5D15QV8kjnGVeD/BHFLwcVr+sn4T6KKmP0WAMs2pww56e4h+eOGHb5iPOufUQXbdbBKi6WV2kk7tefQ==}
-    hasBin: true
-
   openid-client@5.6.4:
     resolution: {integrity: sha512-T1h3B10BRPKfcObdBklX639tVz+xh34O7GjofqrqiAQdm7eHsQ00ih18x6wuJ/E6FxdtS2u3FmUGPDeEcMwzNA==}
 
@@ -3271,10 +3173,6 @@ packages:
   path-to-regexp@0.1.12:
     resolution: {integrity: sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==}
 
-  path-to-regexp@8.2.0:
-    resolution: {integrity: sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==}
-    engines: {node: '>=16'}
-
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
@@ -3314,10 +3212,6 @@ packages:
   pirates@4.0.6:
     resolution: {integrity: sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==}
     engines: {node: '>= 6'}
-
-  pkce-challenge@4.1.0:
-    resolution: {integrity: sha512-ZBmhE1C9LcPoH9XZSdwiPtbPHZROwAnMy+kIFQVrnMCxY4Cudlz3gBOpzilgc0jOgRaiT3sIWfpMomW2ar2orQ==}
-    engines: {node: '>=16.20.0'}
 
   pkg-dir@7.0.0:
     resolution: {integrity: sha512-Ie9z/WINcxxLp27BKOCHGde4ITq9UklYKDzVo1nhk5sqGEXU3FpkwP5GM2voTGJkGd9B3Otl+Q4uwSOeSUtOBA==}
@@ -3483,9 +3377,6 @@ packages:
   pumpify@1.5.1:
     resolution: {integrity: sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==}
 
-  punycode@1.3.2:
-    resolution: {integrity: sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw==}
-
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
@@ -3493,15 +3384,6 @@ packages:
   qs@6.13.0:
     resolution: {integrity: sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==}
     engines: {node: '>=0.6'}
-
-  qs@6.14.0:
-    resolution: {integrity: sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==}
-    engines: {node: '>=0.6'}
-
-  querystring@0.2.0:
-    resolution: {integrity: sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g==}
-    engines: {node: '>=0.4.x'}
-    deprecated: The querystring API is considered Legacy. new code should use the URLSearchParams API instead.
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
@@ -3516,10 +3398,6 @@ packages:
 
   raw-body@2.5.2:
     resolution: {integrity: sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==}
-    engines: {node: '>= 0.8'}
-
-  raw-body@3.0.0:
-    resolution: {integrity: sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g==}
     engines: {node: '>= 0.8'}
 
   react-dom@18.3.1:
@@ -3663,10 +3541,6 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
-  router@2.2.0:
-    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
-    engines: {node: '>= 18'}
-
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
@@ -3695,9 +3569,6 @@ packages:
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
-  sax@1.2.1:
-    resolution: {integrity: sha512-8I2a3LovHTOpm7NV5yOyO8IHqgVsfK4+UuySrXU8YXkSRX7k6hCV9b3HrkKCr3nMpgj+0bmocaJJWpvp1oc7ZA==}
-
   scheduler@0.23.2:
     resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
 
@@ -3714,17 +3585,9 @@ packages:
     resolution: {integrity: sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==}
     engines: {node: '>= 0.8.0'}
 
-  send@1.2.0:
-    resolution: {integrity: sha512-uaW0WwXKpL9blXE2o0bRhoL2EGXIrZxQ2ZQ4mgcfoBxdFmQold+qWsD2jLrfZ0trjKL6vOw0j//eAwcALFjKSw==}
-    engines: {node: '>= 18'}
-
   serve-static@1.16.2:
     resolution: {integrity: sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==}
     engines: {node: '>= 0.8.0'}
-
-  serve-static@2.2.0:
-    resolution: {integrity: sha512-61g9pCh0Vnh7IutZjtLGGpTA355+OPn2TyDv/6ivP2h/AdAVX9azsoxmg2/M6nZeQZNYBEwIcsne1mJd9oQItQ==}
-    engines: {node: '>= 18'}
 
   set-cookie-parser@2.7.1:
     resolution: {integrity: sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==}
@@ -3838,48 +3701,48 @@ packages:
     resolution: {integrity: sha512-MGrFH9Z4NP9Iyhqn16sDtBpRRNJ0Y2hNa6D65h736fVSaPCHr4DM4sWUNvVaSuC+0OBGhwsrydQwmgfg5LncqQ==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
-  sst-darwin-arm64@3.14.24:
-    resolution: {integrity: sha512-ceISCJyF85L+sEagBlO6MSklvqV5UglhhoUxHlLMa5wRCXWvQXyHCPTYHNrNQg3gSOl6PJv7ykMGdlEsdBmMPg==}
+  sst-darwin-arm64@4.1.3:
+    resolution: {integrity: sha512-ZGbMtVHWMJH3/+VFXXO1jAueWAib8EPExgTtoxZN6WEUz+5mvfOd+jz0dq6qL0F9QAyc9P/RZw+CnWdEvUNrmg==}
     cpu: [arm64]
     os: [darwin]
 
-  sst-darwin-x64@3.14.24:
-    resolution: {integrity: sha512-Cfg5LV6l1hR9GcZMjLi3MazKiKBOe/nL45ma7TDm3OMyl+rSXbPJfiP8W8r/t3UgDVpnHvpSKVbIxMj6c+mvPg==}
+  sst-darwin-x64@4.1.3:
+    resolution: {integrity: sha512-X8Ea7ao82Pjqqr0v46mb1XMKTXfWcIaPQDLqwksjjll15M1xCXJTefN9YRSpHl+4Zd5g7JtF1AV4FgM48cF8gA==}
     cpu: [x64]
     os: [darwin]
 
-  sst-linux-arm64@3.14.24:
-    resolution: {integrity: sha512-Ey8Z8ynEX9g7SmndghPN8gPm80+/yaN9kDfJdYh1o7EyKQRQ6TR+s8D31K7UrnNce8biNnh5zQg2012pI+GpzA==}
+  sst-linux-arm64@4.1.3:
+    resolution: {integrity: sha512-dDGqPJwB3RQ4VM5fn8Yzd9rJqRscYm0ueDoiPd/zTec+NfsziIR7duqBlrxS18q5OX6dmWeOxJqbhxvSseHMwQ==}
     cpu: [arm64]
     os: [linux]
 
-  sst-linux-x64@3.14.24:
-    resolution: {integrity: sha512-PovYhCFtOss33Gqw62aCmHhns+s8xieHSUVgCI4jURBQRFJN7+/EnreeBVsEm4Z5i0Tgh2pouiOmZbkHnjsFig==}
+  sst-linux-x64@4.1.3:
+    resolution: {integrity: sha512-i9LjiU5fsJ2iY9tB/vBCaD4MYAog/zmyIG5ApKe4kHIMVKzg/uSpuPON+A/AsJVKlsoDJzjM3sFjjfrH4GoHiA==}
     cpu: [x64]
     os: [linux]
 
-  sst-linux-x86@3.14.24:
-    resolution: {integrity: sha512-vWwZ1w86bvpu73PgAPeO8oTsIVJeG8zpV/Y2vxEZj0U/wewDoM3OmidIE80962J6OvCK51lrpO2Z+XMR3JyTXw==}
+  sst-linux-x86@4.1.3:
+    resolution: {integrity: sha512-z6AXpFB0WXlGvd+1C+g/3H2O11huWT/Mt/ANyd/OXUYxMtmfkIuJrBpcirXYErJOAPjMfXuBS3X7iqYAhkMpHA==}
     cpu: [x86]
     os: [linux]
 
-  sst-win32-arm64@3.14.24:
-    resolution: {integrity: sha512-KkUZ4icdlSHwkrdfwaOnXkDYGkFK7Obu4cU5yGT/ulqD4nyLpK64HmCDMqFbimppa0J+X5mWmO7T6N4ilkBnLA==}
+  sst-win32-arm64@4.1.3:
+    resolution: {integrity: sha512-DyBTtJ+vB0qDGtx2MVtqXDZOTegoCLZ3TX6AYZUZJZTSdvxJq1oYPX5sdhLB/c2UETQSxIBfoUDnTzJHwIyXDQ==}
     cpu: [arm64]
     os: [win32]
 
-  sst-win32-x64@3.14.24:
-    resolution: {integrity: sha512-pXuJ8ajsoE2BkNloyLYs1BasnG6gFdR45o+KIOkvz6hj0QwAayvPdWQjkTCSPuOcMpoPUaPA9P+AQHiTSLWxDw==}
+  sst-win32-x64@4.1.3:
+    resolution: {integrity: sha512-dR9XXjWpH7GzMapdk3JEz0qtHuaEHkgItAqWGGI6YTdSi7wx51/l3F3g76hBfzK+vtmwYkp/ZT4WVXXQ5DKwAQ==}
     cpu: [x64]
     os: [win32]
 
-  sst-win32-x86@3.14.24:
-    resolution: {integrity: sha512-OqW/Z5aqf2j5Rj4bfC1N99AhCEzyvWlrswZvzBAZIuLIWeObHp+3TV9IwgQWNDSQbKmBDxKiqrrx+tzz9lQ+rA==}
+  sst-win32-x86@4.1.3:
+    resolution: {integrity: sha512-M1q0L+7313M4WazuWQpHcK1tnA2TObanvKSQqOm5Knn8y2+2v4OZNpNcyKp/zBRlystyu8P0kcCQFsCU0zKK/A==}
     cpu: [x86]
     os: [win32]
 
-  sst@3.14.24:
-    resolution: {integrity: sha512-+Ml53Vc200POVunGygAHgpj3vH+4Mfu/g8NWNgI/7Lg16dipxrranTq8gLutVPZ61vz0Iu/dfPufIPG1jrk8yw==}
+  sst@4.1.3:
+    resolution: {integrity: sha512-CFfGsWnYC1HNFIoZWlfe8tcffmRQmFoDuMySfZF8doDEpoT0tSzO5TdMCHxmbMoBZ8/ZySpiDbp9KMvBEa2smg==}
     hasBin: true
 
   stable-hash@0.0.4:
@@ -4077,10 +3940,6 @@ packages:
     resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
     engines: {node: '>= 0.6'}
 
-  type-is@2.0.1:
-    resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
-    engines: {node: '>= 0.6'}
-
   typed-array-buffer@1.0.3:
     resolution: {integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==}
     engines: {node: '>= 0.4'}
@@ -4172,9 +4031,6 @@ packages:
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
-  url@0.10.3:
-    resolution: {integrity: sha512-hzSUW2q06EqL1gKM/a+obYHLIO6ct2hwPuviqTTOcfFVc61UbfJ2Q32+uGL/HCPxKqrdGB5QUwIe7UqlDgwsOQ==}
-
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
@@ -4184,10 +4040,6 @@ packages:
   utils-merge@1.0.1:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
-
-  uuid@8.0.0:
-    resolution: {integrity: sha512-jOXGuXZAWdsTH7eZLtyXMqUb9EcWMGZNbL9YcGBJl4MH4nrxHmZJhEHvyLFrkxo+28uLb/NYRcStH48fnD0Vzw==}
-    hasBin: true
 
   uvu@0.5.6:
     resolution: {integrity: sha512-+g8ENReyr8YsOc6fv/NVJs2vFdHBnBNdfE49rshrTzDWOlUx4Gq7KOS2GD8eqhy2j+Ejq29+SbKH8yjkAqXqoA==}
@@ -4338,14 +4190,6 @@ packages:
       utf-8-validate:
         optional: true
 
-  xml2js@0.6.2:
-    resolution: {integrity: sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==}
-    engines: {node: '>=4.0.0'}
-
-  xmlbuilder@11.0.1:
-    resolution: {integrity: sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==}
-    engines: {node: '>=4.0'}
-
   xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
     engines: {node: '>=0.4'}
@@ -4380,14 +4224,6 @@ packages:
   yocto-queue@1.1.1:
     resolution: {integrity: sha512-b4JR1PFR10y1mKjhHY9LaGo6tmrgjit7hxVIeAmyMw3jegXR4dhYqLaQF5zMXZxY7tLpMyJeLjr1C4rLmkVe8g==}
     engines: {node: '>=12.20'}
-
-  zod-to-json-schema@3.24.3:
-    resolution: {integrity: sha512-HIAfWdYIt1sssHfYZFCXp4rU1w2r8hVVXYIlmoa0r0gABLs5di3RCqPU5DDROogVz1pAdYBaz7HK5n9pSUNs3A==}
-    peerDependencies:
-      zod: ^3.24.1
-
-  zod@3.24.2:
-    resolution: {integrity: sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==}
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
@@ -4835,20 +4671,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@modelcontextprotocol/sdk@1.6.1':
-    dependencies:
-      content-type: 1.0.5
-      cors: 2.8.5
-      eventsource: 3.0.7
-      express: 5.1.0
-      express-rate-limit: 7.5.0(express@5.1.0)
-      pkce-challenge: 4.1.0
-      raw-body: 3.0.0
-      zod: 3.24.2
-      zod-to-json-schema: 3.24.3(zod@3.24.2)
-    transitivePeerDependencies:
-      - supports-color
-
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -5128,7 +4950,7 @@ snapshots:
 
   '@protobufjs/utf8@1.1.0': {}
 
-  '@pulumi/aws@6.68.0(typescript@5.7.3)':
+  '@pulumi/aws@7.20.0(typescript@5.7.3)':
     dependencies:
       '@pulumi/pulumi': 3.169.0(typescript@5.7.3)
       mime: 2.6.0
@@ -5445,8 +5267,6 @@ snapshots:
     dependencies:
       defer-to-connect: 2.0.1
 
-  '@tsconfig/bun@1.0.7': {}
-
   '@tufjs/canonical-json@2.0.0': {}
 
   '@tufjs/models@2.0.1':
@@ -5686,11 +5506,6 @@ snapshots:
       mime-types: 2.1.35
       negotiator: 0.6.3
 
-  accepts@2.0.0:
-    dependencies:
-      mime-types: 3.0.1
-      negotiator: 1.0.0
-
   acorn-import-attributes@1.9.5(acorn@8.14.0):
     dependencies:
       acorn: 8.14.0
@@ -5830,19 +5645,6 @@ snapshots:
     dependencies:
       possible-typed-array-names: 1.1.0
 
-  aws-sdk@2.1692.0:
-    dependencies:
-      buffer: 4.9.2
-      events: 1.1.1
-      ieee754: 1.1.13
-      jmespath: 0.16.0
-      querystring: 0.2.0
-      sax: 1.2.1
-      url: 0.10.3
-      util: 0.12.5
-      uuid: 8.0.0
-      xml2js: 0.6.2
-
   aws4fetch@1.0.18: {}
 
   axe-core@4.10.2: {}
@@ -5891,20 +5693,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  body-parser@2.2.0:
-    dependencies:
-      bytes: 3.1.2
-      content-type: 1.0.5
-      debug: 4.4.0
-      http-errors: 2.0.0
-      iconv-lite: 0.6.3
-      on-finished: 2.4.1
-      qs: 6.14.0
-      raw-body: 3.0.0
-      type-is: 2.0.1
-    transitivePeerDependencies:
-      - supports-color
-
   brace-expansion@1.1.11:
     dependencies:
       balanced-match: 1.0.2
@@ -5930,12 +5718,6 @@ snapshots:
       update-browserslist-db: 1.1.2(browserslist@4.24.4)
 
   buffer-from@1.1.2: {}
-
-  buffer@4.9.2:
-    dependencies:
-      base64-js: 1.5.1
-      ieee754: 1.2.1
-      isarray: 1.0.0
 
   buffer@5.7.1:
     dependencies:
@@ -6102,10 +5884,6 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
-  content-disposition@1.0.0:
-    dependencies:
-      safe-buffer: 5.2.1
-
   content-type@1.0.5: {}
 
   convert-source-map@2.0.0: {}
@@ -6119,11 +5897,6 @@ snapshots:
   cookie@0.7.1: {}
 
   core-util-is@1.0.3: {}
-
-  cors@2.8.5:
-    dependencies:
-      object-assign: 4.1.1
-      vary: 1.1.2
 
   cross-spawn@7.0.6:
     dependencies:
@@ -6661,14 +6434,6 @@ snapshots:
 
   event-target-shim@5.0.1: {}
 
-  events@1.1.1: {}
-
-  eventsource-parser@3.0.2: {}
-
-  eventsource@3.0.7:
-    dependencies:
-      eventsource-parser: 3.0.2
-
   execa@5.1.1:
     dependencies:
       cross-spawn: 7.0.6
@@ -6684,10 +6449,6 @@ snapshots:
   exit-hook@2.2.1: {}
 
   exponential-backoff@3.1.2: {}
-
-  express-rate-limit@7.5.0(express@5.1.0):
-    dependencies:
-      express: 5.1.0
 
   express@4.21.2:
     dependencies:
@@ -6721,38 +6482,6 @@ snapshots:
       statuses: 2.0.1
       type-is: 1.6.18
       utils-merge: 1.0.1
-      vary: 1.1.2
-    transitivePeerDependencies:
-      - supports-color
-
-  express@5.1.0:
-    dependencies:
-      accepts: 2.0.0
-      body-parser: 2.2.0
-      content-disposition: 1.0.0
-      content-type: 1.0.5
-      cookie: 0.7.1
-      cookie-signature: 1.2.2
-      debug: 4.4.0
-      encodeurl: 2.0.0
-      escape-html: 1.0.3
-      etag: 1.8.1
-      finalhandler: 2.1.0
-      fresh: 2.0.0
-      http-errors: 2.0.0
-      merge-descriptors: 2.0.0
-      mime-types: 3.0.1
-      on-finished: 2.4.1
-      once: 1.4.0
-      parseurl: 1.3.3
-      proxy-addr: 2.0.7
-      qs: 6.14.0
-      range-parser: 1.2.1
-      router: 2.2.0
-      send: 1.2.0
-      serve-static: 2.2.0
-      statuses: 2.0.1
-      type-is: 2.0.1
       vary: 1.1.2
     transitivePeerDependencies:
       - supports-color
@@ -6805,17 +6534,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  finalhandler@2.1.0:
-    dependencies:
-      debug: 4.4.0
-      encodeurl: 2.0.0
-      escape-html: 1.0.3
-      on-finished: 2.4.1
-      parseurl: 1.3.3
-      statuses: 2.0.1
-    transitivePeerDependencies:
-      - supports-color
-
   find-up@5.0.0:
     dependencies:
       locate-path: 6.0.0
@@ -6850,8 +6568,6 @@ snapshots:
   fraction.js@4.3.7: {}
 
   fresh@0.5.2: {}
-
-  fresh@2.0.0: {}
 
   fs-constants@1.0.0: {}
 
@@ -7054,8 +6770,6 @@ snapshots:
 
   hast-util-whitespace@2.0.1: {}
 
-  hono@4.7.4: {}
-
   hosted-git-info@6.1.3:
     dependencies:
       lru-cache: 7.18.3
@@ -7102,12 +6816,11 @@ snapshots:
   iconv-lite@0.6.3:
     dependencies:
       safer-buffer: 2.1.2
+    optional: true
 
   icss-utils@5.1.0(postcss@8.5.1):
     dependencies:
       postcss: 8.5.1
-
-  ieee754@1.1.13: {}
 
   ieee754@1.2.1: {}
 
@@ -7267,8 +6980,6 @@ snapshots:
 
   is-plain-obj@4.1.0: {}
 
-  is-promise@4.0.0: {}
-
   is-reference@3.0.3:
     dependencies:
       '@types/estree': 1.0.6
@@ -7344,8 +7055,6 @@ snapshots:
   javascript-stringify@2.1.0: {}
 
   jiti@1.21.7: {}
-
-  jmespath@0.16.0: {}
 
   jose@4.15.9: {}
 
@@ -7606,11 +7315,7 @@ snapshots:
 
   media-typer@0.3.0: {}
 
-  media-typer@1.1.0: {}
-
   merge-descriptors@1.0.3: {}
-
-  merge-descriptors@2.0.0: {}
 
   merge-stream@2.0.0: {}
 
@@ -7840,15 +7545,9 @@ snapshots:
 
   mime-db@1.53.0: {}
 
-  mime-db@1.54.0: {}
-
   mime-types@2.1.35:
     dependencies:
       mime-db: 1.52.0
-
-  mime-types@3.0.1:
-    dependencies:
-      mime-db: 1.54.0
 
   mime@1.6.0: {}
 
@@ -7961,8 +7660,6 @@ snapshots:
   negotiator@0.6.3: {}
 
   negotiator@0.6.4: {}
-
-  negotiator@1.0.0: {}
 
   node-gyp@10.3.1:
     dependencies:
@@ -8128,16 +7825,6 @@ snapshots:
     dependencies:
       mimic-fn: 2.1.0
 
-  opencontrol@0.0.6:
-    dependencies:
-      '@modelcontextprotocol/sdk': 1.6.1
-      '@tsconfig/bun': 1.0.7
-      hono: 4.7.4
-      zod: 3.24.2
-      zod-to-json-schema: 3.24.3(zod@3.24.2)
-    transitivePeerDependencies:
-      - supports-color
-
   openid-client@5.6.4:
     dependencies:
       jose: 4.15.9
@@ -8264,8 +7951,6 @@ snapshots:
 
   path-to-regexp@0.1.12: {}
 
-  path-to-regexp@8.2.0: {}
-
   path-type@4.0.0: {}
 
   pathe@1.1.2: {}
@@ -8295,8 +7980,6 @@ snapshots:
   pify@2.3.0: {}
 
   pirates@4.0.6: {}
-
-  pkce-challenge@4.1.0: {}
 
   pkg-dir@7.0.0:
     dependencies:
@@ -8462,19 +8145,11 @@ snapshots:
       inherits: 2.0.4
       pump: 2.0.1
 
-  punycode@1.3.2: {}
-
   punycode@2.3.1: {}
 
   qs@6.13.0:
     dependencies:
       side-channel: 1.1.0
-
-  qs@6.14.0:
-    dependencies:
-      side-channel: 1.1.0
-
-  querystring@0.2.0: {}
 
   queue-microtask@1.2.3: {}
 
@@ -8487,13 +8162,6 @@ snapshots:
       bytes: 3.1.2
       http-errors: 2.0.0
       iconv-lite: 0.4.24
-      unpipe: 1.0.0
-
-  raw-body@3.0.0:
-    dependencies:
-      bytes: 3.1.2
-      http-errors: 2.0.0
-      iconv-lite: 0.6.3
       unpipe: 1.0.0
 
   react-dom@18.3.1(react@18.3.1):
@@ -8687,16 +8355,6 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.34.6
       fsevents: 2.3.3
 
-  router@2.2.0:
-    dependencies:
-      debug: 4.4.0
-      depd: 2.0.0
-      is-promise: 4.0.0
-      parseurl: 1.3.3
-      path-to-regexp: 8.2.0
-    transitivePeerDependencies:
-      - supports-color
-
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
@@ -8730,8 +8388,6 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
-  sax@1.2.1: {}
-
   scheduler@0.23.2:
     dependencies:
       loose-envify: 1.4.0
@@ -8758,37 +8414,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  send@1.2.0:
-    dependencies:
-      debug: 4.4.0
-      encodeurl: 2.0.0
-      escape-html: 1.0.3
-      etag: 1.8.1
-      fresh: 2.0.0
-      http-errors: 2.0.0
-      mime-types: 3.0.1
-      ms: 2.1.3
-      on-finished: 2.4.1
-      range-parser: 1.2.1
-      statuses: 2.0.1
-    transitivePeerDependencies:
-      - supports-color
-
   serve-static@1.16.2:
     dependencies:
       encodeurl: 2.0.0
       escape-html: 1.0.3
       parseurl: 1.3.3
       send: 0.19.0
-    transitivePeerDependencies:
-      - supports-color
-
-  serve-static@2.2.0:
-    dependencies:
-      encodeurl: 2.0.0
-      escape-html: 1.0.3
-      parseurl: 1.3.3
-      send: 1.2.0
     transitivePeerDependencies:
       - supports-color
 
@@ -8921,48 +8552,44 @@ snapshots:
     dependencies:
       minipass: 7.1.2
 
-  sst-darwin-arm64@3.14.24:
+  sst-darwin-arm64@4.1.3:
     optional: true
 
-  sst-darwin-x64@3.14.24:
+  sst-darwin-x64@4.1.3:
     optional: true
 
-  sst-linux-arm64@3.14.24:
+  sst-linux-arm64@4.1.3:
     optional: true
 
-  sst-linux-x64@3.14.24:
+  sst-linux-x64@4.1.3:
     optional: true
 
-  sst-linux-x86@3.14.24:
+  sst-linux-x86@4.1.3:
     optional: true
 
-  sst-win32-arm64@3.14.24:
+  sst-win32-arm64@4.1.3:
     optional: true
 
-  sst-win32-x64@3.14.24:
+  sst-win32-x64@4.1.3:
     optional: true
 
-  sst-win32-x86@3.14.24:
+  sst-win32-x86@4.1.3:
     optional: true
 
-  sst@3.14.24:
+  sst@4.1.3:
     dependencies:
-      aws-sdk: 2.1692.0
       aws4fetch: 1.0.18
       jose: 5.2.3
-      opencontrol: 0.0.6
       openid-client: 5.6.4
     optionalDependencies:
-      sst-darwin-arm64: 3.14.24
-      sst-darwin-x64: 3.14.24
-      sst-linux-arm64: 3.14.24
-      sst-linux-x64: 3.14.24
-      sst-linux-x86: 3.14.24
-      sst-win32-arm64: 3.14.24
-      sst-win32-x64: 3.14.24
-      sst-win32-x86: 3.14.24
-    transitivePeerDependencies:
-      - supports-color
+      sst-darwin-arm64: 4.1.3
+      sst-darwin-x64: 4.1.3
+      sst-linux-arm64: 4.1.3
+      sst-linux-x64: 4.1.3
+      sst-linux-x86: 4.1.3
+      sst-win32-arm64: 4.1.3
+      sst-win32-x64: 4.1.3
+      sst-win32-x86: 4.1.3
 
   stable-hash@0.0.4: {}
 
@@ -9211,12 +8838,6 @@ snapshots:
       media-typer: 0.3.0
       mime-types: 2.1.35
 
-  type-is@2.0.1:
-    dependencies:
-      content-type: 1.0.5
-      media-typer: 1.1.0
-      mime-types: 3.0.1
-
   typed-array-buffer@1.0.3:
     dependencies:
       call-bound: 1.0.3
@@ -9333,11 +8954,6 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  url@0.10.3:
-    dependencies:
-      punycode: 1.3.2
-      querystring: 0.2.0
-
   util-deprecate@1.0.2: {}
 
   util@0.12.5:
@@ -9349,8 +8965,6 @@ snapshots:
       which-typed-array: 1.1.18
 
   utils-merge@1.0.1: {}
-
-  uuid@8.0.0: {}
 
   uvu@0.5.6:
     dependencies:
@@ -9511,13 +9125,6 @@ snapshots:
 
   ws@7.5.10: {}
 
-  xml2js@0.6.2:
-    dependencies:
-      sax: 1.2.1
-      xmlbuilder: 11.0.1
-
-  xmlbuilder@11.0.1: {}
-
   xtend@4.0.2: {}
 
   y18n@5.0.8: {}
@@ -9543,11 +9150,5 @@ snapshots:
   yocto-queue@0.1.0: {}
 
   yocto-queue@1.1.1: {}
-
-  zod-to-json-schema@3.24.3(zod@3.24.2):
-    dependencies:
-      zod: 3.24.2
-
-  zod@3.24.2: {}
 
   zwitch@2.0.4: {}


### PR DESCRIPTION
- ReactとNext.jsにおいて以下の脆弱性が出ていると公式ブログの中で言及
https://react.dev/blog/2025/12/03/critical-security-vulnerability-in-react-server-components
https://nextjs.org/blog/CVE-2025-66478

- 以下のlangfuse公式のgithub discussionにて言及されていた 
https://github.com/orgs/langfuse/discussions/10977


- CVE-2025-55182 / 66478の脆弱性対策が今回の修正で完了したことの証明
```
React 19.0〜19.2.0 / Next 15.x の特定バージョンが対象

React / Next.js 公式が提示している「修正版」のバージョン

React 19.2.1 以上、Next 15.5.7 などが「修正版」として明示されている

Langfuse v3.137.0 以降が、それらの修正版に依存するようにアップデートされている

リリースノートに upgrade react to 19.2.1 and next 15.5.7 と記載

v3.139.0 の web/package.json を見ると、実際に react: 19.2.1, next: 15.5.7 を利用している

公式 Docker イメージはそのタグのソースからビルドされている
```

- 上記の対応を行うため以下のdocker-imageにグレードアップ
  - web用のlangfuseのベースイメージ
https://hub.docker.com/layers/langfuse/langfuse/3.139.0/images/sha256-708cd9b4906b4882091ddda7bd071fa55e3e59bd3314da62be47adca7500e819

  - async-worker用のlangfuseのベースイメージ
https://hub.docker.com/layers/langfuse/langfuse-worker/3.139.0/images/sha256-12d195f839c3942b7275facf41e28d56949166d1979611479f78172f81559c21

- 参考資料
https://github.com/langfuse/langfuse/releases/tag/v3.137.0
https://github.com/langfuse/langfuse/blob/v3.139.0/web/package.json#L131
https://github.com/langfuse/langfuse/blob/v3.139.0/web/package.json#L142
